### PR TITLE
EDITOR: Camera settings fix

### DIFF
--- a/editor/source/editor-core/inspector/nau_object_inspector.cpp
+++ b/editor/source/editor-core/inspector/nau_object_inspector.cpp
@@ -514,7 +514,9 @@ NauPropertyInt::NauPropertyInt(const std::string& propertyTitle, NauWidget* pare
 void NauPropertyInt::setValueInternal(const NauAnyType& value)
 {
     NED_ASSERT(value.canConvert<int>());
-    m_spinBox->setValue(value.convert<int>());
+    if (!m_spinBox->hasFocus()) {
+        m_spinBox->setValue(value.convert<int>());
+    }
 }
 
 NauAnyType NauPropertyInt::getValue()
@@ -548,7 +550,9 @@ NauPropertyReal::NauPropertyReal(const std::string& propertyTitle, NauWidget* pa
 void NauPropertyReal::setValueInternal(const NauAnyType& value)
 {
     NED_ASSERT(value.canConvert<float>());
-    m_spinBox->setValue(value.convert<float>());
+    if (!m_spinBox->hasFocus()) {
+        m_spinBox->setValue(value.convert<float>());
+    }
 }
 
 NauAnyType NauPropertyReal::getValue()
@@ -892,7 +896,9 @@ QString NauStringLineView::getValue() const
 
 void NauStringLineView::setValue(const QString& value)
 {
-    m_lineEdit->setText(value);
+    if (!m_lineEdit->hasFocus()) {
+        m_lineEdit->setText(value);
+    }
 }
 
 

--- a/editor/source/modules/nau-scene-editor/src/viewport/nau_scene_camera_controller.cpp
+++ b/editor/source/modules/nau-scene-editor/src/viewport/nau_scene_camera_controller.cpp
@@ -347,6 +347,11 @@ void NauSceneCameraController::changeCameraSpeed(float deltaSpeed)
     m_internalController.changeCameraSpeed(deltaSpeed);
 }
 
+void NauSceneCameraController::setCameraSpeed(float speed)
+{
+    m_internalController.setCameraSpeed(speed);
+}
+
 void NauSceneCameraController::focusOn(const nau::math::mat4& matrix, int distanceMeters )
 {
     m_internalController.focusOn(matrix, distanceMeters);

--- a/editor/source/modules/nau-scene-editor/src/viewport/nau_scene_camera_controller.hpp
+++ b/editor/source/modules/nau-scene-editor/src/viewport/nau_scene_camera_controller.hpp
@@ -87,6 +87,7 @@ class NauSceneCameraController final : public NauCameraControllerInterface
 public:
     void updateCameraMovement(float deltaTime, const NauViewportInput& input) override;
     void changeCameraSpeed(float deltaSpeed) override;
+    void setCameraSpeed(float speed);
     void focusOn(const nau::math::mat4& matrix, int distanceMeters = 5) override;
 
     bool isCameraActive(const NauViewportInput& input) const override;

--- a/editor/source/modules/nau-scene-editor/src/widgets/nau_scene_camera_settings.cpp
+++ b/editor/source/modules/nau-scene-editor/src/widgets/nau_scene_camera_settings.cpp
@@ -272,7 +272,7 @@ NauSceneCameraMovementSettings::NauSceneCameraMovementSettings(QWidget* parent)
         auto& sceneEditor = Nau::EditorServiceProvider().get<NauUsdSceneEditorInterface>();
         auto sceneCameraController = dynamic_cast<NauSceneCameraController*>(sceneEditor.sceneCameraController().get());
         if (sceneCameraController) {
-            sceneCameraController->changeCameraSpeed(speed);
+            sceneCameraController->setCameraSpeed(speed);
         }
     });
 


### PR DESCRIPTION
Some of the camera settings were not available to be edited proreply because of frequent UI updates rewriting the field. Also speed changes were calculated incorrectly in case user entered a value, because it was treated as a delta change. 

Implemented: 
setValueInternal in NauPropertyReal and NauPropertyInt only goes through when field is not focused
setCameraSpeed in NauSceneCamera to allow proper change