### PR TITLE
EDITOR: Fix camera frustum rendering when gizmo is out of view

### DIFF
--- a/editor/source/editor-engine/include/nau/gizmo/nau_camera_gizmo.hpp
+++ b/editor/source/editor-engine/include/nau/gizmo/nau_camera_gizmo.hpp
@@ -38,6 +38,7 @@ protected:
     virtual nau::math::vec3 calculateDelta(const nau::math::vec2& pivot2d, const nau::math::vec3& ax, const nau::math::vec3& ay, const nau::math::vec3& az) override;
     virtual void renderInternal(const nau::math::mat4& transform, int selectedAxes) override;
     virtual Axes detectHoveredAxes(nau::math::vec2 screenPoint) override;
+    virtual bool isOnScreen() const override;
 
 private:
     std::vector<nau::math::Point3> m_frustumPoints;

--- a/editor/source/editor-engine/include/nau/gizmo/nau_gizmo.hpp
+++ b/editor/source/editor-engine/include/nau/gizmo/nau_gizmo.hpp
@@ -87,6 +87,8 @@ protected:
     virtual void renderInternal(const nau::math::mat4& basis, int selectedAxes) = 0;
     virtual Axes detectHoveredAxes(nau::math::vec2 screenPoint) = 0;
 
+    virtual bool isOnScreen() const;
+
     const NauBasis2D& basis2d() { return m_basis2d; }
 
 private:

--- a/editor/source/editor-engine/src/gizmo/nau_camera_gizmo.cpp
+++ b/editor/source/editor-engine/src/gizmo/nau_camera_gizmo.cpp
@@ -32,6 +32,17 @@ static bool isPointInSphere(const nau::math::vec2& point, const nau::math::vec3&
     return true;
 }
 
+static bool isFrustumOnScreen(const nau::math::mat4& basis, const std::vector<nau::math::Point3>& frustumPoints)
+{
+    for (const auto& pt : frustumPoints) {
+        nau::math::vec3 worldPt = basis * Vectormath::SSE::Vector3(pt.getX(), pt.getY(), pt.getZ());
+        nau::math::vec2 screen;
+        if (Nau::Utils::worldToScreen(worldPt, screen)) {
+            return true;
+        }
+    }
+    return false;
+}
 
 // ** NauCameraGizmo
 
@@ -49,6 +60,11 @@ void NauCameraGizmo::setCallback(NauCameraGizmo::UpdateCallback callback)
 nau::math::vec3 NauCameraGizmo::calculateDelta(const nau::math::vec2& pivot2d, const nau::math::vec3& ax, const nau::math::vec3& ay, const nau::math::vec3& az)
 {
     return {};
+}
+
+bool NauCameraGizmo::isOnScreen() const
+{
+    return isFrustumOnScreen(m_basis3d, m_frustumPoints);
 }
 
 void NauCameraGizmo::renderInternal(const nau::math::mat4& transform, int selectedAxes)

--- a/editor/source/editor-engine/src/gizmo/nau_gizmo.cpp
+++ b/editor/source/editor-engine/src/gizmo/nau_gizmo.cpp
@@ -94,9 +94,14 @@ NauGizmoAbstract::~NauGizmoAbstract()
     }
 }
 
+bool NauGizmoAbstract::isOnScreen() const
+{
+    return isGizmoOnScreen(m_basis3d);
+}
+
 void NauGizmoAbstract::render()
 {
-    if (!m_isActive || !isGizmoOnScreen(m_basis3d)) {
+    if (!m_isActive || !isOnScreen()) {
         return;
     }
 


### PR DESCRIPTION
Added separate check for camera to determine if it is on screen and should be rendered. 
Before, if camera object is out of view, its frustum wouldn't render. New function checks for camera frustum. 